### PR TITLE
GHC/Build/Link: relativize absolute rpaths + self-$ORIGIN (forward-port onto master)

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
@@ -671,7 +671,18 @@ getRPaths pbci = do
             | isRelative p = hostPref </> p
             | otherwise    = hostPref </> shortRelativePath relDir p
           rpaths =
-            toNubListR (map relPath libraryPaths)
+            -- Always search the artifact's own directory ($ORIGIN /
+            -- @loader_path) first, so a sibling library installed alongside it
+            -- is found by the dynamic loader. depLibraryPaths can yield the
+            -- parent directory for a same-directory dependency (relativized to
+            -- "$ORIGIN/.."), which leaves the dependency unfound. glibc papers
+            -- over this via the runtime LD_LIBRARY_PATH GHC sets before
+            -- dlopen, but musl reads LD_LIBRARY_PATH only at process startup,
+            -- so the missing self-rpath is fatal there: a Backpack signature
+            -- implementation (libHSp) installed next to the instantiated unit
+            -- (libHSindef) fails to load (testsuite T14304 on Alpine/musl).
+            toNubListR [hostPref]
+              <> toNubListR (map relPath libraryPaths)
               <> toNubListR (map getSymbolicPath $ extraLibDirs bi)
       return rpaths
     else return mempty

--- a/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
@@ -55,6 +55,8 @@ import System.FilePath
   , replaceExtension
   )
 
+import Distribution.Simple.InstallDirs (bindir, libdir)
+
 -- | Links together the object files of the Haskell modules and extra sources
 -- using the context in which the component is being built.
 --
@@ -624,7 +626,45 @@ getRPaths pbci = do
       let hostPref = case hostOS of
             OSX -> "@loader_path"
             _ -> "$ORIGIN"
-          relPath p = if isRelative p then hostPref </> p else p
+          -- The artifact's eventual install directory; absolute rpaths are
+          -- expressed as `@loader_path`/`$ORIGIN`-relative to this when the
+          -- user has opted into relocatable mode (`relocatable: True` or
+          -- `--enable-relocatable`).
+          --
+          -- Mirrors the executable/library split in
+          -- 'Distribution.Simple.LocalBuildInfo.depLibraryPaths'.
+          installDirs = absoluteComponentInstallDirs
+            (localPkgDescr lbi) lbi (componentUnitId clbi) NoCopyDest
+          isExe = case clbi of
+            ExeComponentLocalBuildInfo{} -> True
+            _ -> False
+          relDir
+            | isExe     = bindir installDirs
+            | otherwise = libdir installDirs
+          -- Convert an rpath entry to its loader-relative form.
+          --
+          -- * Already-relative paths get the `@loader_path` / `$ORIGIN`
+          --   prefix as before.
+          -- * Absolute paths normally pass through unchanged. In
+          --   `relocatable` mode we replace them with a relative-form
+          --   expression (`@loader_path/../../...`) computed against the
+          --   binary's install dir, so the resulting binary does not bake
+          --   a build-host absolute path into LC_RPATH / DT_RUNPATH.
+          --
+          --   This matters on macOS 15 (Sequoia), whose dyld treats an
+          --   unresolvable absolute rpath as fatal — older dyld silently
+          --   falls through to subsequent rpath entries. Pre-fix, a
+          --   bindist produced under e.g.
+          --   `/Volumes/WorkSpace/_work/ghc/ghc/_build/stage2/store/...`
+          --   would abort-trap on launch when relocated off the build
+          --   host. Post-fix, the same entry becomes
+          --   `@loader_path/../../<sibling-pkg>/lib`, which dyld treats
+          --   as a normal missing-directory rpath when the bindist
+          --   layout no longer matches the store layout.
+          relPath p
+            | isRelative p   = hostPref </> p
+            | relocatable lbi = hostPref </> shortRelativePath relDir p
+            | otherwise      = p
           rpaths =
             toNubListR (map relPath libraryPaths)
               <> toNubListR (map getSymbolicPath $ extraLibDirs bi)

--- a/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
@@ -645,11 +645,10 @@ getRPaths pbci = do
           --
           -- * Already-relative paths get the `@loader_path` / `$ORIGIN`
           --   prefix as before.
-          -- * Absolute paths normally pass through unchanged. In
-          --   `relocatable` mode we replace them with a relative-form
-          --   expression (`@loader_path/../../...`) computed against the
-          --   binary's install dir, so the resulting binary does not bake
-          --   a build-host absolute path into LC_RPATH / DT_RUNPATH.
+          -- * Absolute paths are rewritten to a relative-form expression
+          --   (`@loader_path/../../...`) computed against the binary's
+          --   install dir, so the resulting binary does not bake a
+          --   build-host absolute path into LC_RPATH / DT_RUNPATH.
           --
           --   This matters on macOS 15 (Sequoia), whose dyld treats an
           --   unresolvable absolute rpath as fatal — older dyld silently
@@ -661,10 +660,16 @@ getRPaths pbci = do
           --   `@loader_path/../../<sibling-pkg>/lib`, which dyld treats
           --   as a normal missing-directory rpath when the bindist
           --   layout no longer matches the store layout.
+          --
+          --   Not gated on `relocatable lbi`: that flag also triggers
+          --   `checkRelocatable` (which refuses cabal-store layouts
+          --   where deps live in sibling prefixes) and changes how
+          --   library-dirs are emitted in .conf files. Both behaviors
+          --   are independent of rpath generation and incompatible with
+          --   the stable-haskell GHC bindist assembly pipeline.
           relPath p
-            | isRelative p   = hostPref </> p
-            | relocatable lbi = hostPref </> shortRelativePath relDir p
-            | otherwise      = p
+            | isRelative p = hostPref </> p
+            | otherwise    = hostPref </> shortRelativePath relDir p
           rpaths =
             toNubListR (map relPath libraryPaths)
               <> toNubListR (map getSymbolicPath $ extraLibDirs bi)


### PR DESCRIPTION
**Draft / forward-port for review.** Brings the absolute-rpath relativization
to post-split `stable-haskell/master` and adds a self-`$ORIGIN` rpath entry.

### What

Three commits onto `stable-haskell/master`:

1. *(Andrea)* `GHC/Build/Link: relativize absolute rpaths when --enable-relocatable`
2. *(Andrea)* `GHC/Build/Link: drop the relocatable gate, always relativize abs rpaths`
3. *(new)* `GHC/Build/Link: include $ORIGIN/@loader_path in rpaths`

(1)+(2) are #368 (`feat/rpath-relativize-absolute`), which currently targets the
**pre-split** `feature/rebase-CI`; this is the same change rebased onto
post-split `master`, where `getRPaths` still bakes absolute build-host paths
into `LC_RPATH`/`DT_RUNPATH`.

(3) is new: `getRPaths` never adds the artifact's *own* directory to the
runpath. For a dependency that ends up in the **same** directory (a Backpack
signature impl `libHSp` next to the instantiated `libHSindef`),
`depLibraryPaths` yields the parent and it relativizes to `$ORIGIN/..` — so the
dep isn't found. glibc papers over it via the runtime `LD_LIBRARY_PATH` GHC
sets before `dlopen`; musl reads `LD_LIBRARY_PATH` only at startup, so it's
fatal there (GHC testsuite `backpack/cabal/T14304` on Alpine/musl; passes on
every glibc platform). Prepending the loader-relative self dir is relative, so
it does not reintroduce the absolute path (1)+(2) remove (no macOS regression).

### Why here

This is part of reconciling the cross/dual-compiler stack onto `master`. The
fixes the stable-haskell GHC build needs (#361 tool-guess, #368 rpath, this
`$ORIGIN` follow-up, and the stage-qualified/host-only work in #378) are spread
across pre- and post-split feature branches; `master` has none of the rpath
work. `stable-haskell/ghc` currently has to pin the *pre-split*
`feature/wasm-cross-ghcup-stack` to get these, which forces it to also revert
GHC's `Setup.hs` to the pre-`VerbosityHandles` API and drop `hooks-exe`. Landing
the rpath stack on `master` (alongside #361 and #378) removes that need.

### Caveat

Cherry-picked cleanly (no conflicts) but **not built locally** — please let CI
validate, particularly that the relativization still typechecks against the
post-split `LocalBuildInfo`/`InstallDirs` API (`absoluteComponentInstallDirs`,
`NoCopyDest`, `bindir`/`libdir`). Filing as **draft** for @andreabedini's review;
could alternatively stack on `wip/andrea/stage-qualified-options`.
